### PR TITLE
set php memory_limit based on Lambda memory config

### DIFF
--- a/Bootstrap/service.php
+++ b/Bootstrap/service.php
@@ -31,7 +31,7 @@ if ($lambdaMemorySize) {
     if (!is_numeric($lambdaMemorySize)) {
         printf("AWS_LAMBDA_FUNCTION_MEMORY_SIZE expected to be numeric, '%s' given\n", $lambdaMemorySize);
     } else {
-        $phpMemoryLimit = (int)$lambdaMemorySize - self::RESERVED_MEMORY_SIZE;
+        $phpMemoryLimit = (int)$lambdaMemorySize - RESERVED_MEMORY_SIZE;
         printf("Configured memory: %d MB; setting memory_limit to %d MB\n", $lambdaMemorySize, $phpMemoryLimit);
         ini_set('memory_limit', sprintf("%dM", $phpMemoryLimit));
     }

--- a/Bootstrap/service.php
+++ b/Bootstrap/service.php
@@ -9,7 +9,7 @@ use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 
 // memory to save for system overhead (in MB)
-const RESERVED_MEMORY_SIZE = 96;
+const DEFAULT_RESERVED_MEMORY_SIZE = 96;
 
 set_time_limit(0);
 
@@ -29,12 +29,18 @@ $handlerService = getenv('_HANDLER') ?: 'Dayspring\LambdaBundle\Service\EchoLamb
 $lambdaMemorySize = getenv('AWS_LAMBDA_FUNCTION_MEMORY_SIZE');
 if ($lambdaMemorySize) {
     if (!is_numeric($lambdaMemorySize)) {
-        printf("AWS_LAMBDA_FUNCTION_MEMORY_SIZE expected to be numeric, '%s' given\n", $lambdaMemorySize);
-    } else {
-        $phpMemoryLimit = (int)$lambdaMemorySize - RESERVED_MEMORY_SIZE;
-        printf("Configured memory: %d MB; setting memory_limit to %d MB\n", $lambdaMemorySize, $phpMemoryLimit);
-        ini_set('memory_limit', sprintf("%dM", $phpMemoryLimit));
+        die(sprintf("AWS_LAMBDA_FUNCTION_MEMORY_SIZE expected to be numeric, '%s' given\n", $lambdaMemorySize));
     }
+
+    $reservedMemorySize = getenv('RESERVED_MEMORY_SIZE') ?: DEFAULT_RESERVED_MEMORY_SIZE;
+    if (!is_numeric($reservedMemorySize)) {
+        printf("RESERVED_MEMORY_SIZE expected to be numeric, '%s' given; using default.\n", $reservedMemorySize);
+        $reservedMemorySize = DEFAULT_RESERVED_MEMORY_SIZE;
+    }
+
+    $phpMemoryLimit = (int)$lambdaMemorySize - $reservedMemorySize;
+    printf("Configured memory: %d MB; setting memory_limit to %d MB\n", $lambdaMemorySize, $phpMemoryLimit);
+    ini_set('memory_limit', sprintf("%dM", $phpMemoryLimit));
 }
 
 

--- a/Bootstrap/service.php
+++ b/Bootstrap/service.php
@@ -8,6 +8,9 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 
+// memory to save for system overhead (in MB)
+const RESERVED_MEMORY_SIZE = 96;
+
 set_time_limit(0);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
@@ -22,6 +25,17 @@ $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable('console');
 $env = getenv('SYMFONY_ENV') ?: 'dev';
 $debug = getenv('SYMFONY_DEBUG') !== '0' && $env !== 'prod';
 $handlerService = getenv('_HANDLER') ?: 'Dayspring\LambdaBundle\Service\EchoLambdaHandlerService';
+
+$lambdaMemorySize = getenv('AWS_LAMBDA_FUNCTION_MEMORY_SIZE');
+if ($lambdaMemorySize) {
+    if (!is_numeric($lambdaMemorySize)) {
+        printf("AWS_LAMBDA_FUNCTION_MEMORY_SIZE expected to be numeric, '%s' given\n", $lambdaMemorySize);
+    } else {
+        $phpMemoryLimit = (int)$lambdaMemorySize - self::RESERVED_MEMORY_SIZE;
+        printf("Configured memory: %d MB; setting memory_limit to %d MB\n", $lambdaMemorySize, $phpMemoryLimit);
+        ini_set('memory_limit', sprintf("%dM", $phpMemoryLimit));
+    }
+}
 
 
 if ($debug) {
@@ -53,6 +67,11 @@ while (true) {
 
         $out = $output->fetch();
         echo $out;
+
+        // calculate peak memory usage and output
+        $peakMemoryUsage = memory_get_peak_usage();
+        $peakMemoryUsageMB = $peakMemoryUsage / 1024 / 1024;
+        printf("PHP peak memory usage: %d MB\n", $peakMemoryUsageMB);
 
         return $returnValue;
     });


### PR DESCRIPTION
AWS Lambda provides an environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` with the functions configured memory limit. This uses that value to set PHP's memory limit, minus some amount for the system.

The amount reserved for system can be configured by setting a `RESERVED_MEMORY_SIZE` environment variable to the number of MB to reserve.

closes #2 