### PR TITLE
add an init function for handlers to do any one-time setup

### DIFF
--- a/Bootstrap/service.php
+++ b/Bootstrap/service.php
@@ -55,6 +55,8 @@ try {
     $kernel->boot();
 
     $service = $kernel->getContainer()->get($handlerService);
+
+    $service->init();
 } catch (Exception $e) {
     // error getting service
     $lambdaRuntime->failInitialization(sprintf(

--- a/Service/EchoLambdaHandlerService.php
+++ b/Service/EchoLambdaHandlerService.php
@@ -20,6 +20,11 @@ class EchoLambdaHandlerService implements LambdaHandlerServiceInterface
         $this->logger = $logger;
     }
 
+    public function init()
+    {
+        // nothing to init
+    }
+
     public function handle($event, Context $context, OutputInterface $output): array
     {
         $output->writeln($event['body']);

--- a/Service/LambdaHandlerServiceInterface.php
+++ b/Service/LambdaHandlerServiceInterface.php
@@ -7,5 +7,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 interface LambdaHandlerServiceInterface
 {
+    public function init();
+
     public function handle($event, Context $context, OutputInterface $output): array;
 }

--- a/Service/ServiceFunctionHandlerService.php
+++ b/Service/ServiceFunctionHandlerService.php
@@ -34,6 +34,11 @@ class ServiceFunctionHandlerService implements LambdaHandlerServiceInterface
         $this->container = $container;
     }
 
+    public function init()
+    {
+        // nothing to init
+    }
+
 
     public function handle($event, Context $context, OutputInterface $output): array
     {

--- a/Service/SqsLambdaHandlerService.php
+++ b/Service/SqsLambdaHandlerService.php
@@ -20,6 +20,11 @@ class SqsLambdaHandlerService implements LambdaHandlerServiceInterface
         $this->logger = $logger;
     }
 
+    public function init()
+    {
+        // nothing to init
+    }
+
     public function handle($event, Context $context, OutputInterface $output): array
     {
         foreach ($event['Records'] as $e) {

--- a/Service/SqsServiceFunctionHandlerService.php
+++ b/Service/SqsServiceFunctionHandlerService.php
@@ -36,6 +36,11 @@ class SqsServiceFunctionHandlerService extends ServiceFunctionHandlerService
         $this->container = $container;
     }
 
+    public function init()
+    {
+        // nothing to init
+    }
+
 
     public function handle($event, Context $context, OutputInterface $output): array
     {


### PR DESCRIPTION
Implementations that use Propel can disable instance pooling during handler `init()`

closes #5 